### PR TITLE
demo更新，新版本sdk不需要传递dnsIp，由sdk内部调度

### DIFF
--- a/HttpDnsSample/app/src/main/java/com/yx/dnsTest/MainActivity.kt
+++ b/HttpDnsSample/app/src/main/java/com/yx/dnsTest/MainActivity.kt
@@ -27,7 +27,7 @@ class MainActivity : AppCompatActivity() {
         // 配置项
         val dnsConfigBuilder = DnsConfig.Builder()
             .dnsId("dnsId")
-            .dnsIp("119.29.29.98")
+            .dnsIp("x.x.x.x")
             .desHttp()
             .dnsKey("dnsKey")
             .logLevel(Log.VERBOSE)

--- a/HttpDnsSample/app/src/main/java/com/yx/dnsTest/MainActivity.kt
+++ b/HttpDnsSample/app/src/main/java/com/yx/dnsTest/MainActivity.kt
@@ -27,7 +27,6 @@ class MainActivity : AppCompatActivity() {
         // 配置项
         val dnsConfigBuilder = DnsConfig.Builder()
             .dnsId("dnsId")
-            .dnsIp("x.x.x.x")
             .desHttp()
             .dnsKey("dnsKey")
             .logLevel(Log.VERBOSE)


### PR DESCRIPTION
demo更新，新版本sdk不需要传递dnsIp，由sdk内部调度